### PR TITLE
update error message and allow coul 0 1 1 for break no

### DIFF
--- a/doc/src/Howto_bpm.rst
+++ b/doc/src/Howto_bpm.rst
@@ -109,7 +109,7 @@ charges in BPM models, setting a nonzero coul weight for 1-2 bonds
 ensures all bonded neighbors are still included in the neighbor list
 in case bonds break between neighbor list builds. If bond breakage is
 disabled during a simulation run by setting the *break* keyword to *no*,
-a zero coul weight for 1-2 bonds can be used to exclude bonded neighbors
+a zero coul weight for 1-2 bonds can be used to exclude bonded atoms
 from the neighbor list builds. This can be useful for post-processing,
 or to determine pair interaction properties between distinct bonded particles.
 

--- a/doc/src/Howto_bpm.rst
+++ b/doc/src/Howto_bpm.rst
@@ -107,7 +107,11 @@ bond lists is expensive.  By setting the lj weight for 1-2 bonds to
 zero, this turns off pairwise interactions.  Even though there are no
 charges in BPM models, setting a nonzero coul weight for 1-2 bonds
 ensures all bonded neighbors are still included in the neighbor list
-in case bonds break between neighbor list builds.
+in case bonds break between neighbor list builds. If bond breakage is
+disabled during a simulation run by setting the *break* keyword to *no*,
+a zero coul weight for 1-2 bonds can be used to exclude bonded neighbors
+from the neighbor list builds. This can be useful for post-processing,
+or to determine pair interaction properties between distinct bonded particles.
 
 To monitor the fracture of bonds in the system, all BPM bond styles
 have the ability to record instances of bond breakage to output using

--- a/doc/src/bond_bpm_rotational.rst
+++ b/doc/src/bond_bpm_rotational.rst
@@ -234,8 +234,8 @@ This bond style is part of the BPM package.  It is only enabled if
 LAMMPS was built with that package.  See the :doc:`Build package
 <Build_package>` page for more info.
 
-By default if pair interactions are to be disabled, this bond style
-requires setting
+By default if pair interactions between bonded atoms are to be disabled,
+this bond style requires setting
 
 .. code-block:: LAMMPS
 

--- a/doc/src/bond_bpm_spring.rst
+++ b/doc/src/bond_bpm_spring.rst
@@ -191,8 +191,8 @@ This bond style is part of the BPM package.  It is only enabled if
 LAMMPS was built with that package.  See the :doc:`Build package
 <Build_package>` page for more info.
 
-By default if pair interactions are to be disabled, this bond style
-requires setting
+By default if pair interactions between bonded atoms are to be disabled,
+this bond style requires setting
 
 .. code-block:: LAMMPS
 

--- a/src/BPM/bond_bpm.cpp
+++ b/src/BPM/bond_bpm.cpp
@@ -106,7 +106,7 @@ void BondBPM::init_style()
   } else {
     // Require atoms know about all of their bonds and if they break
     if (force->newton_bond && break_flag)
-      error->all(FLERR, "With overlay/pair no, or break no, BPM bond styles require Newton bond off");
+      error->all(FLERR, "With overlay/pair no, or break yes, BPM bond styles require Newton bond off");
 
     // special lj must be 0 1 1 to censor pair forces between bonded particles
     if (force->special_lj[1] != 0.0 || force->special_lj[2] != 1.0 || force->special_lj[3] != 1.0)

--- a/src/BPM/bond_bpm.cpp
+++ b/src/BPM/bond_bpm.cpp
@@ -96,7 +96,7 @@ void BondBPM::init_style()
   if (overlay_flag) {
     if (force->special_lj[1] != 1.0)
       error->all(FLERR,
-                 "With overlay/pair, BPM bond styles require special_bonds weight of 1.0 for "
+                 "With overlay/pair yes, BPM bond styles require special_bonds weight of 1.0 for "
                  "first neighbors");
     if (id_fix_update) {
       modify->delete_fix(id_fix_update);
@@ -106,18 +106,18 @@ void BondBPM::init_style()
   } else {
     // Require atoms know about all of their bonds and if they break
     if (force->newton_bond && break_flag)
-      error->all(FLERR, "Without overlay/pair or break/no, BPM bond styles require Newton bond off");
+      error->all(FLERR, "With overlay/pair no, or break no, BPM bond styles require Newton bond off");
 
     // special lj must be 0 1 1 to censor pair forces between bonded particles
-    // special coulomb must be 1 1 1 to ensure all pairs are included in the
-    //   neighbor list and 1-3 and 1-4 special bond lists are skipped
     if (force->special_lj[1] != 0.0 || force->special_lj[2] != 1.0 || force->special_lj[3] != 1.0)
       error->all(FLERR,
-                 "Without overlay/pair, BPM bond styles requires special LJ weights = 0,1,1");
-    if (force->special_coul[1] != 1.0 || force->special_coul[2] != 1.0 ||
-        force->special_coul[3] != 1.0)
+                 "With overlay/pair no, BPM bond styles require special LJ weights = 0,1,1");
+    // if bonds can break, special coulomb must be 1 1 1 to ensure all pairs are included in the
+    //    neighbor list and 1-3 and 1-4 special bond lists are skipped
+    if (break_flag && (force->special_coul[1] != 1.0 || force->special_coul[2] != 1.0 ||
+        force->special_coul[3] != 1.0))
       error->all(FLERR,
-                 "Without overlay/pair, BPM bond styles requires special Coulomb weights = 1,1,1");
+                 "With overlay/pair no, and break yes, BPM bond styles requires special Coulomb weights = 1,1,1");
 
     if (id_fix_dummy && break_flag) {
       id_fix_update = utils::strdup("BPM_UPDATE_SPECIAL_BONDS");
@@ -335,7 +335,7 @@ void BondBPM::read_restart(FILE *fp)
 void BondBPM::process_broken(int i, int j)
 {
   if (!break_flag)
-    error->one(FLERR, "BPM bond broke with break/no option");
+    error->one(FLERR, "BPM bond broke with break no option");
   if (fix_store_local) {
     for (int n = 0; n < nvalues; n++) (this->*pack_choice[n])(n, i, j);
 


### PR DESCRIPTION
**Summary**

Cosmetic changes on error messages

allow special_bonds coul 0 1 1 when break no. There is no risk to interfere with neighbor list builds between bond breakage when there is no bond breakage. Eliminating bonded atoms from neighbor list can be useful for post-processing or to get per BPM pair quantities such as number of contacts.

**Related Issue(s)**

None

**Author(s)**

Jibrl B. Coulibaly (SNL)

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

yes

**Implementation Notes**

N/A

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

N/A


